### PR TITLE
[codex] fix terminal IME and Kimi project indexing

### DIFF
--- a/src-tauri/src/agents/kimi.rs
+++ b/src-tauri/src/agents/kimi.rs
@@ -52,6 +52,7 @@ struct KimiSessionRecord {
     main_wire_path: PathBuf,
     id: String,
     cwd: String,
+    cwd_key: String,
     title: String,
     created: Option<String>,
     modified: u64,
@@ -267,6 +268,55 @@ fn session_files_mtime(session_dir: &Path) -> u64 {
         maximum = maximum.max(mtime_millis(&agent_dir.path().join("wire.jsonl")));
     }
     maximum
+}
+
+fn lexical_normalized_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let _ = normalized.pop();
+            }
+            Component::Normal(segment) => normalized.push(segment),
+        }
+    }
+    normalized
+}
+
+fn normalized_path_text(path: &Path) -> String {
+    let mut value = path.to_string_lossy().replace('\\', "/");
+    while value.len() > 1 && value.ends_with('/') {
+        value.pop();
+    }
+    #[cfg(windows)]
+    {
+        value.make_ascii_lowercase();
+        if value.len() == 2 && value.as_bytes()[1] == b':' {
+            value.push('/');
+        }
+    }
+    value
+}
+
+/// Kimi may persist the same workspace with different separators, trailing
+/// slashes, relative segments, or (on Windows) path casing. Use a stable key
+/// for grouping and lookups while retaining `cwd` for display and metadata.
+fn kimi_project_key(value: &str) -> String {
+    let path = Path::new(value.trim());
+    let normalized = if path.is_absolute() {
+        path.canonicalize()
+            .unwrap_or_else(|_| lexical_normalized_path(path))
+    } else {
+        lexical_normalized_path(path)
+    };
+    normalized_path_text(&normalized)
+}
+
+fn session_dir_key(path: &Path) -> String {
+    normalized_path_text(path)
 }
 
 fn is_regular_non_symlink(path: &Path) -> bool {
@@ -1033,6 +1083,7 @@ fn record_from_session_dir(root: &Path, session_dir: &Path) -> Option<KimiSessio
         session_dir,
         main_wire_path,
         id,
+        cwd_key: kimi_project_key(&cwd),
         cwd,
         title,
     })
@@ -1054,7 +1105,7 @@ fn discover_session_records(root: &Path) -> Result<Vec<KimiSessionRecord>, Strin
         let Some(session_dir) = valid_session_dir(root, &candidate) else {
             continue;
         };
-        if !seen.insert(session_dir.clone()) {
+        if !seen.insert(session_dir_key(&session_dir)) {
             continue;
         }
         if let Some(record) = record_from_session_dir(root, &session_dir) {
@@ -1076,11 +1127,16 @@ fn find_main_wire_path_at(root: &Path, session_id: &str, cwd: Option<&str>) -> O
     if session_id.is_empty() {
         return None;
     }
-    let cwd = cwd.map(str::trim).filter(|cwd| !cwd.is_empty());
+    let cwd = cwd
+        .map(str::trim)
+        .filter(|cwd| !cwd.is_empty())
+        .map(kimi_project_key);
     discover_session_records(root)
         .ok()?
         .into_iter()
-        .find(|record| record.id == session_id && cwd.is_none_or(|cwd| record.cwd == cwd))
+        .find(|record| {
+            record.id == session_id && cwd.as_ref().is_none_or(|cwd| &record.cwd_key == cwd)
+        })
         .map(|record| record.main_wire_path)
 }
 
@@ -1875,7 +1931,7 @@ impl SessionSource for KimiSource {
         let mut projects: HashMap<String, ProjectInfo> = HashMap::new();
         for record in discover_session_records(&kimi_home())? {
             let project = projects
-                .entry(record.cwd.clone())
+                .entry(record.cwd_key.clone())
                 .or_insert_with(|| ProjectInfo {
                     dir_name: record.cwd.clone(),
                     display_path: record.cwd.clone(),
@@ -1902,9 +1958,10 @@ impl SessionSource for KimiSource {
         _include_codex_internal: bool,
         _include_codex_archived: bool,
     ) -> Result<SessionPage, String> {
+        let project_key = kimi_project_key(project_key);
         let mut records: Vec<KimiSessionRecord> = discover_session_records(&kimi_home())?
             .into_iter()
-            .filter(|record| record.cwd == project_key)
+            .filter(|record| record.cwd_key == project_key)
             .collect();
         records.sort_by_key(|record| std::cmp::Reverse(record.modified));
         let total = records.len();
@@ -2184,6 +2241,21 @@ mod tests {
         assert_eq!(meta.path, wire.canonicalize().unwrap().to_string_lossy());
         assert_eq!(meta.message_count, 2);
         assert!(meta.size > 0);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn normalizes_cwd_aliases_to_one_project_key() {
+        let root = scratch("cwd-key");
+        let project = root.join("project");
+        fs::create_dir_all(&project).unwrap();
+        let canonical = project.to_string_lossy().to_string();
+        let dotted = format!("{canonical}/./");
+        assert_eq!(kimi_project_key(&canonical), kimi_project_key(&dotted));
+        assert_eq!(
+            kimi_project_key(&canonical),
+            kimi_project_key(&format!("{canonical}/"))
+        );
         let _ = fs::remove_dir_all(root);
     }
 
@@ -3167,6 +3239,10 @@ mod tests {
         );
         assert_eq!(
             find_main_wire_path_at(&root, "hook-id", Some("/tmp/project")),
+            Some(wire.canonicalize().unwrap())
+        );
+        assert_eq!(
+            find_main_wire_path_at(&root, "hook-id", Some("/tmp/./project/")),
             Some(wire.canonicalize().unwrap())
         );
         assert_eq!(

--- a/src/style.css
+++ b/src/style.css
@@ -5155,9 +5155,11 @@ body.is-tab-reordering * {
   color: var(--terminal-inverse-fg) !important;
 }
 /* Windows IME 的候选框锚定 xterm 隐藏 textarea；拼音预编辑文本则在 composition-view。
- * Working 时把两者固定到静态输入光标，避免 Codex 状态刷新带着输入法上下跳动。 */
+ * Working 或 Codex composition 期间把两者固定到静态输入光标，避免 TUI 重绘带着输入法上下跳动。 */
 .terminal-stable-cursor .xterm-helper-textarea,
-.terminal-stable-cursor .composition-view {
+.terminal-stable-cursor .composition-view,
+.terminal-ime-anchor .xterm-helper-textarea,
+.terminal-ime-anchor .composition-view {
   left: var(--terminal-stable-cursor-left) !important;
   top: var(--terminal-stable-cursor-top) !important;
 }

--- a/src/terminals.ts
+++ b/src/terminals.ts
@@ -213,6 +213,15 @@ export function createTerminalImeInputDeduper() {
       // 覆盖 xterm 自己的延迟提交，以及 Caps Lock 触发的紧邻第二次提交。
       clearTimer = setTimeout(clear, IME_DEDUP_WINDOW_MS)
     },
+    onCompositionCancel() {
+      if (clearTimer !== undefined) clearTimeout(clearTimer)
+      if (capsTimer !== undefined) clearTimeout(capsTimer)
+      clearTimer = undefined
+      capsTimer = undefined
+      capsBuffer = ''
+      awaitingCompositionInput = false
+      forwardedData = undefined
+    },
     consume(data: string): string | null {
       if (capsTimer !== undefined) {
         capsBuffer += data
@@ -1655,9 +1664,18 @@ export async function openOrFocusTui(opts: OpenTuiOptions): Promise<void> {
   activateTabInPane(tab)
   if (tab.agent === 'codex' && !tab.isShell) tab.container.classList.add('terminal-codex-tui')
   term.onWriteParsed(() => {
-    if (!shouldUseStableTerminalCursor(tab.agent, tab.turnState, !!tab.isShell)) return
-    captureStableTerminalCursor(tab, true)
-    syncStableTerminalCursorGeometry(tab)
+    const imeAnchored = tab.container.classList.contains('terminal-ime-anchor')
+    if (shouldUseStableTerminalCursor(tab.agent, tab.turnState, !!tab.isShell)) {
+      if (!imeAnchored) captureStableTerminalCursor(tab, true)
+      syncStableTerminalCursorGeometry(tab)
+      return
+    }
+    // During an idle Codex composition the real cursor may still be moved by
+    // TUI redraws. Keep the IME anchor geometry, but do not replace the
+    // visible terminal cursor outside the working state.
+    if (tab.container.classList.contains('terminal-ime-anchor')) {
+      syncStableTerminalCursorGeometry(tab)
+    }
   })
   term.onRender(() => {
     if (shouldUseStableTerminalCursor(tab.agent, tab.turnState, !!tab.isShell)) {
@@ -1665,15 +1683,53 @@ export async function openOrFocusTui(opts: OpenTuiOptions): Promise<void> {
     }
   })
   const imeInputDeduper = createTerminalImeInputDeduper()
+  let imeComposing = false
+  let imeAnchorReleaseTimer: ReturnType<typeof setTimeout> | undefined
   term.textarea?.addEventListener('compositionstart', () => {
+    imeComposing = true
+    if (imeAnchorReleaseTimer !== undefined) {
+      clearTimeout(imeAnchorReleaseTimer)
+      imeAnchorReleaseTimer = undefined
+    }
+    if (_isWindows && tab.agent === 'codex' && !tab.isShell) {
+      captureStableTerminalCursor(tab)
+      syncStableTerminalCursorGeometry(tab)
+      tab.container.classList.add('terminal-ime-anchor')
+    }
     tab.container.classList.add('terminal-ime-composing')
   })
   term.textarea?.addEventListener('compositionend', () => {
+    imeComposing = false
     tab.container.classList.remove('terminal-ime-composing')
+    if (tab.container.classList.contains('terminal-ime-anchor')) {
+      // xterm schedules its final composition data with a zero-delay timer;
+      // release the CSS anchor after that callback so the candidate window
+      // does not jump during the final commit.
+      imeAnchorReleaseTimer = setTimeout(() => {
+        imeAnchorReleaseTimer = undefined
+        tab.container.classList.remove('terminal-ime-anchor')
+      }, 0)
+    }
     imeInputDeduper.onCompositionEnd()
   })
+  term.textarea?.addEventListener('compositioncancel', () => {
+    imeComposing = false
+    tab.container.classList.remove('terminal-ime-composing')
+    if (imeAnchorReleaseTimer !== undefined) {
+      clearTimeout(imeAnchorReleaseTimer)
+      imeAnchorReleaseTimer = undefined
+    }
+    tab.container.classList.remove('terminal-ime-anchor')
+    imeInputDeduper.onCompositionCancel()
+  })
   term.attachCustomKeyEventHandler((ev) => {
-    if (ev.type === 'keydown' && shouldBufferTerminalImeSwitch(ev)) imeInputDeduper.onInputMethodSwitch()
+    if (
+      ev.type === 'keydown'
+      && (imeComposing || ev.isComposing || ev.keyCode === 229)
+      && shouldBufferTerminalImeSwitch(ev)
+    ) {
+      imeInputDeduper.onInputMethodSwitch()
+    }
     if (handleWindowsTerminalSelectionCopy(term, ev)) return false
     if (
       handleWindowsTerminalSelectionDelete(
@@ -1980,6 +2036,7 @@ export async function openShellTab(opts: {
   })
 
   term.textarea?.addEventListener('compositionend', () => imeInputDeduper.onCompositionEnd())
+  term.textarea?.addEventListener('compositioncancel', () => imeInputDeduper.onCompositionCancel())
 
   const writeShellInput = (data: string) => {
     if (tab.ptyId === null || tab.processState !== 'alive') return

--- a/test/terminals.test.ts
+++ b/test/terminals.test.ts
@@ -183,6 +183,25 @@ describe('terminal IME input', () => {
     }
   })
 
+  it('clears pending IME input when composition is canceled', () => {
+    vi.useFakeTimers()
+    try {
+      const flushed: string[] = []
+      const deduper = createTerminalImeInputDeduper()
+      deduper.setFlushHandler((data) => flushed.push(data))
+      deduper.onInputMethodSwitch()
+      expect(deduper.consume('g')).toBeNull()
+
+      deduper.onCompositionCancel()
+      vi.advanceTimersByTime(120)
+
+      expect(flushed).toEqual([])
+      expect(deduper.consume('grok')).toBe('grok')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('accepts the same text as a new input after the debounce window', () => {
     vi.useFakeTimers()
     try {


### PR DESCRIPTION
## Summary

- Stabilize the Windows IME candidate anchor during Codex TUI composition and release it after xterm finishes the final commit.
- Prevent ordinary Shift/CapsLock input from entering the IME dedupe buffer unless a real composition is active; clear pending state on composition cancellation.
- Normalize Kimi cwd and physical session-directory keys so path aliases are grouped as one project and hook lookup uses the same key.
- Add regression coverage for IME cancellation, cwd aliases, and hook lookup.

## Root cause

- Codex TUI redraws move xterm's hidden textarea and composition view while the IME candidate window is open.
- The input deduper buffered input-method switch keys without checking whether composition was active, which delayed normal committed text.
- Kimi project grouping used raw cwd strings, so separator, casing, trailing-slash, and dot-segment variants could produce duplicate projects.

## Validation

- `vitest run test/terminals.test.ts`: 41 tests passed.
- `vue-tsc --noEmit`: passed.
- `rustfmt --edition 2021 --check src-tauri/src/agents/kimi.rs`: passed.
- `git diff --check`: passed.

`cargo test`/`cargo check` could not run in the current Windows environment because MSVC `link.exe` is unavailable.
